### PR TITLE
use tracing + generate request ids

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ strum = "^0.26"
 urlencoding = "^2.1"
 utoipa = "^4.2"
 tracing = { version = "^0.1", features = ["attributes"] }
+tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json"] }
 sqlx = { version = "^0.7", features = [
     "runtime-tokio",
     "tls-rustls",

--- a/crates/iceberg-rest-bin/Cargo.toml
+++ b/crates/iceberg-rest-bin/Cargo.toml
@@ -23,8 +23,7 @@ path = "src/main.rs"
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 axum = { workspace = true }
-clap = { workspace = true }
-env_logger = { workspace = true }
+clap = { version = "^4.5", features = ["derive"] }
 headers = { workspace = true }
 http = { workspace = true }
 iceberg-rest-server = { path = "../iceberg-rest-server", features = [
@@ -36,9 +35,9 @@ iceberg-rest-server = { path = "../iceberg-rest-server", features = [
 iceberg-rest-service = { path = "../iceberg-rest-service", features = [
     "tokio",
 ] }
-log = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }
 tower-http = { workspace = true }
 tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
 uuid = { workspace = true }

--- a/crates/iceberg-rest-bin/src/main.rs
+++ b/crates/iceberg-rest-bin/src/main.rs
@@ -7,6 +7,8 @@ use iceberg_rest_server::{
     },
     service::router::{new_full_router, serve as service_serve},
 };
+use tracing_subscriber::filter::LevelFilter;
+use tracing_subscriber::EnvFilter;
 
 #[derive(Parser)]
 #[command(version, about, long_about = None)]
@@ -63,7 +65,18 @@ async fn serve(bind_addr: std::net::SocketAddr) -> Result<(), anyhow::Error> {
 async fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
 
-    env_logger::init();
+    tracing_subscriber::fmt()
+        // Configure the subscriber to emit logs in JSON format.
+        .json()
+        // Configure the subscriber to flatten event fields in the output JSON objects.
+        .flatten_event(true)
+        // Set the subscriber as the default, returning an error if this fails.
+        .with_env_filter(
+            EnvFilter::builder()
+                .with_default_directive(LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .init();
 
     match cli.command {
         Some(Commands::Migrate {}) => {

--- a/crates/iceberg-rest-bin/src/main.rs
+++ b/crates/iceberg-rest-bin/src/main.rs
@@ -12,9 +12,9 @@ use iceberg_rest_server::{
     service::router::{new_full_router, serve as service_serve},
     CONFIG,
 };
+use std::sync::Arc;
 use tracing_subscriber::filter::LevelFilter;
 use tracing_subscriber::EnvFilter;
-use std::sync::Arc;
 
 #[derive(Parser)]
 #[command(version, about, long_about = None)]

--- a/crates/iceberg-rest-server/Cargo.toml
+++ b/crates/iceberg-rest-server/Cargo.toml
@@ -44,7 +44,8 @@ sqlx = { workspace = true, optional = true }
 strum = { workspace = true }
 strum_macros = { workspace = true }
 tokio = { workspace = true, optional = true }
-tower-http = { workspace = true, optional = true }
+tower-http = { workspace = true, optional = true, features = ["default", "request-id", "util"] }
+tower = { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true }
 urlencoding = { workspace = true }

--- a/crates/iceberg-rest-server/src/api/mod.rs
+++ b/crates/iceberg-rest-server/src/api/mod.rs
@@ -23,6 +23,7 @@ pub mod v1 {
     };
     pub mod warehouse;
     use crate::service::event_publisher::EventPublisher;
+    use crate::tracing::REQUEST_ID;
     use warehouse::WarehouseService;
 
     impl<C: Catalog, A: AuthZHandler, S: SecretStore, P: EventPublisher> super::ApiServer<C, A, S, P> {

--- a/crates/iceberg-rest-server/src/api/mod.rs
+++ b/crates/iceberg-rest-server/src/api/mod.rs
@@ -1,7 +1,6 @@
 use std::marker::PhantomData;
 
 use axum::{extract::State as AxumState, routing::post, Json, Router};
-use http::HeaderMap;
 use iceberg_rest_service::ApiContext;
 
 use crate::service::event_publisher::EventPublisher;
@@ -18,12 +17,12 @@ pub struct ApiServer<C: Catalog, A: AuthZHandler, S: SecretStore, P: EventPublis
 
 pub mod v1 {
     use super::{
-        post, ApiContext, AuthZHandler, AxumState, Catalog, HeaderMap, Json, Router, SecretStore,
-        State,
+        post, ApiContext, AuthZHandler, AxumState, Catalog, Json, Router, SecretStore, State,
     };
+    use axum::Extension;
+    use iceberg_rest_service::RequestMetadata;
     pub mod warehouse;
     use crate::service::event_publisher::EventPublisher;
-    use crate::tracing::REQUEST_ID;
     use warehouse::WarehouseService;
 
     impl<C: Catalog, A: AuthZHandler, S: SecretStore, P: EventPublisher> super::ApiServer<C, A, S, P> {
@@ -35,9 +34,9 @@ pub mod v1 {
                 // List Namespaces
                 post(
                     |AxumState(api_context): AxumState<ApiContext<State<A, C, S, P>>>,
-                     headers: HeaderMap,
+                     Extension(metadata): Extension<RequestMetadata>,
                      Json(request): Json<warehouse::CreateWarehouseRequest>| {
-                        Self::create_warehouse(request, api_context, headers)
+                        Self::create_warehouse(request, api_context, metadata)
                     },
                 ),
             )

--- a/crates/iceberg-rest-server/src/api/v1/warehouse.rs
+++ b/crates/iceberg-rest-server/src/api/v1/warehouse.rs
@@ -2,8 +2,7 @@ use crate::api::ApiServer;
 use crate::service::event_publisher::EventPublisher;
 use crate::service::storage::{StorageCredential, StorageProfile};
 use crate::service::{auth::AuthZHandler, secrets::SecretStore, Catalog, State, Transaction};
-use http::HeaderMap;
-use iceberg_rest_service::{ApiContext, Result};
+use iceberg_rest_service::{ApiContext, RequestMetadata, Result};
 use utoipa::ToSchema;
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, ToSchema)]
@@ -44,7 +43,7 @@ pub trait WarehouseService<C: Catalog, A: AuthZHandler, S: SecretStore, P: Event
     async fn create_warehouse(
         request: CreateWarehouseRequest,
         context: ApiContext<State<A, C, S, P>>,
-        _headers: HeaderMap,
+        _request_metadata: RequestMetadata,
     ) -> Result<CreateWarehouseResponse> {
         let CreateWarehouseRequest {
             warehouse_name,

--- a/crates/iceberg-rest-server/src/catalog/config.rs
+++ b/crates/iceberg-rest-server/src/catalog/config.rs
@@ -1,9 +1,9 @@
-use http::HeaderMap;
 use http::StatusCode;
 use iceberg_rest_service::v1::config::GetConfigQueryParams;
 use iceberg_rest_service::v1::{
     ApiContext, CatalogConfig, ErrorModel, IcebergErrorResponse, Result,
 };
+use iceberg_rest_service::RequestMetadata;
 use std::marker::PhantomData;
 use std::str::FromStr;
 
@@ -78,10 +78,13 @@ impl<
     async fn get_config(
         query: GetConfigQueryParams,
         api_context: ApiContext<State<A, D, S, P>>,
-        headers: HeaderMap,
+        request_metadata: RequestMetadata,
     ) -> Result<CatalogConfig> {
-        let auth_info =
-            T::get_and_validate_user_warehouse(api_context.v1_state.auth.clone(), &headers).await?;
+        let auth_info = T::get_and_validate_user_warehouse(
+            api_context.v1_state.auth.clone(),
+            &request_metadata,
+        )
+        .await?;
 
         let UserWarehouse {
             user_id,
@@ -155,7 +158,7 @@ impl<
         // Give the auth-handler a chance to exchange / enrich the token
         let new_token = T::exchange_token_for_warehouse(
             api_context.v1_state.auth.clone(),
-            &headers,
+            &request_metadata,
             &project_id,
             &warehouse_id,
         );

--- a/crates/iceberg-rest-server/src/catalog/metrics.rs
+++ b/crates/iceberg-rest-server/src/catalog/metrics.rs
@@ -1,5 +1,5 @@
-use http::HeaderMap;
 use iceberg_rest_service::v1::{ApiContext, Result, TableParameters};
+use iceberg_rest_service::RequestMetadata;
 
 use crate::service::event_publisher::EventPublisher;
 use crate::service::{auth::AuthZHandler, secrets::SecretStore, Catalog, State};
@@ -14,7 +14,7 @@ impl<C: Catalog, A: AuthZHandler, S: SecretStore, P: EventPublisher>
         _: TableParameters,
         _: serde_json::Value,
         _: ApiContext<State<A, C, S, P>>,
-        _: HeaderMap,
+        _: RequestMetadata,
     ) -> Result<()> {
         // ToDo: implement
         Ok(())

--- a/crates/iceberg-rest-server/src/catalog/namespace.rs
+++ b/crates/iceberg-rest-server/src/catalog/namespace.rs
@@ -1,5 +1,4 @@
 use crate::CONFIG;
-use http::HeaderMap;
 use http::StatusCode;
 use iceberg::NamespaceIdent;
 use iceberg_rest_service::v1::{
@@ -7,6 +6,7 @@ use iceberg_rest_service::v1::{
     ListNamespacesQuery, ListNamespacesResponse, NamespaceParameters, Prefix, Result,
     UpdateNamespacePropertiesRequest, UpdateNamespacePropertiesResponse,
 };
+use iceberg_rest_service::RequestMetadata;
 
 use super::{require_warehouse_id, CatalogServer};
 use crate::service::event_publisher::EventPublisher;
@@ -27,7 +27,7 @@ impl<C: Catalog, A: AuthZHandler, S: SecretStore, P: EventPublisher>
         prefix: Option<Prefix>,
         query: ListNamespacesQuery,
         state: ApiContext<State<A, C, S, P>>,
-        headers: HeaderMap,
+        request_metadata: RequestMetadata,
     ) -> Result<ListNamespacesResponse> {
         // ------------------- VALIDATIONS -------------------
         let warehouse_id = require_warehouse_id(prefix)?;
@@ -40,7 +40,7 @@ impl<C: Catalog, A: AuthZHandler, S: SecretStore, P: EventPublisher>
 
         // ------------------- AUTHZ -------------------
         A::check_list_namespace(
-            &headers,
+            &request_metadata,
             &warehouse_id,
             query.parent.as_ref(),
             state.v1_state.auth,
@@ -55,7 +55,7 @@ impl<C: Catalog, A: AuthZHandler, S: SecretStore, P: EventPublisher>
         prefix: Option<Prefix>,
         request: CreateNamespaceRequest,
         state: ApiContext<State<A, C, S, P>>,
-        headers: HeaderMap,
+        request_metadata: RequestMetadata,
     ) -> Result<CreateNamespaceResponse> {
         // ------------------- VALIDATIONS -------------------
         let warehouse_id = require_warehouse_id(prefix)?;
@@ -83,7 +83,7 @@ impl<C: Catalog, A: AuthZHandler, S: SecretStore, P: EventPublisher>
 
         // ------------------- AUTHZ -------------------
         A::check_create_namespace(
-            &headers,
+            &request_metadata,
             &warehouse_id,
             request.namespace.parent().as_ref(),
             state.v1_state.auth,
@@ -101,7 +101,7 @@ impl<C: Catalog, A: AuthZHandler, S: SecretStore, P: EventPublisher>
     async fn load_namespace_metadata(
         parameters: NamespaceParameters,
         state: ApiContext<State<A, C, S, P>>,
-        headers: HeaderMap,
+        request_metadata: RequestMetadata,
     ) -> Result<GetNamespaceResponse> {
         // ------------------- VALIDATIONS -------------------
         let warehouse_id = require_warehouse_id(parameters.prefix)?;
@@ -109,7 +109,7 @@ impl<C: Catalog, A: AuthZHandler, S: SecretStore, P: EventPublisher>
 
         // ------------------- AUTHZ -------------------
         A::check_load_namespace_metadata(
-            &headers,
+            &request_metadata,
             &warehouse_id,
             &parameters.namespace,
             state.v1_state.auth,
@@ -128,7 +128,7 @@ impl<C: Catalog, A: AuthZHandler, S: SecretStore, P: EventPublisher>
     async fn namespace_exists(
         parameters: NamespaceParameters,
         state: ApiContext<State<A, C, S, P>>,
-        headers: HeaderMap,
+        request_metadata: RequestMetadata,
     ) -> Result<()> {
         //  ------------------- VALIDATIONS -------------------
         let warehouse_id = require_warehouse_id(parameters.prefix)?;
@@ -136,7 +136,7 @@ impl<C: Catalog, A: AuthZHandler, S: SecretStore, P: EventPublisher>
 
         //  ------------------- AUTHZ -------------------
         A::check_namespace_exists(
-            &headers,
+            &request_metadata,
             &warehouse_id,
             &parameters.namespace,
             state.v1_state.auth,
@@ -163,7 +163,7 @@ impl<C: Catalog, A: AuthZHandler, S: SecretStore, P: EventPublisher>
     async fn drop_namespace(
         parameters: NamespaceParameters,
         state: ApiContext<State<A, C, S, P>>,
-        headers: HeaderMap,
+        request_metadata: RequestMetadata,
     ) -> Result<()> {
         //  ------------------- VALIDATIONS -------------------
         let warehouse_id = require_warehouse_id(parameters.prefix)?;
@@ -183,7 +183,7 @@ impl<C: Catalog, A: AuthZHandler, S: SecretStore, P: EventPublisher>
 
         //  ------------------- AUTHZ -------------------
         A::check_drop_namespace(
-            &headers,
+            &request_metadata,
             &warehouse_id,
             &parameters.namespace,
             state.v1_state.auth,
@@ -202,7 +202,7 @@ impl<C: Catalog, A: AuthZHandler, S: SecretStore, P: EventPublisher>
         parameters: NamespaceParameters,
         request: UpdateNamespacePropertiesRequest,
         state: ApiContext<State<A, C, S, P>>,
-        headers: HeaderMap,
+        request_metadata: RequestMetadata,
     ) -> Result<UpdateNamespacePropertiesResponse> {
         //  ------------------- VALIDATIONS -------------------
         let warehouse_id = require_warehouse_id(parameters.prefix)?;
@@ -219,7 +219,7 @@ impl<C: Catalog, A: AuthZHandler, S: SecretStore, P: EventPublisher>
 
         //  ------------------- AUTHZ -------------------
         A::check_update_namespace_properties(
-            &headers,
+            &request_metadata,
             &warehouse_id,
             &parameters.namespace,
             state.v1_state.auth,

--- a/crates/iceberg-rest-server/src/implementations/authz.rs
+++ b/crates/iceberg-rest-server/src/implementations/authz.rs
@@ -6,8 +6,7 @@ use crate::{
     },
     ProjectIdent, WarehouseIdent,
 };
-use http::HeaderMap;
-use iceberg_rest_service::{v1::NamespaceIdent, Result};
+use iceberg_rest_service::{v1::NamespaceIdent, RequestMetadata, Result};
 
 #[derive(Clone, Debug, Default)]
 pub struct AllowAllAuthState;
@@ -20,7 +19,7 @@ pub struct AllowAllAuthZHandler;
 impl AuthConfigHandler<AllowAllAuthZHandler> for AllowAllAuthZHandler {
     async fn get_and_validate_user_warehouse(
         _: AllowAllAuthState,
-        _: &HeaderMap,
+        _: &RequestMetadata,
     ) -> Result<UserWarehouse> {
         // The AuthHandler should return the user's project or warehouse if this
         // information is available. Otherwise return "None".
@@ -35,7 +34,7 @@ impl AuthConfigHandler<AllowAllAuthZHandler> for AllowAllAuthZHandler {
 
     async fn exchange_token_for_warehouse(
         _: AllowAllAuthState,
-        _: &HeaderMap,
+        _: &RequestMetadata,
         _: &ProjectIdent,
         _: &WarehouseIdent,
     ) -> Result<Option<String>> {
@@ -64,7 +63,7 @@ impl AuthZHandler for AllowAllAuthZHandler {
     type State = AllowAllAuthState;
 
     async fn check_list_namespace(
-        _: &HeaderMap,
+        _: &RequestMetadata,
         _: &WarehouseIdent,
         _: Option<&NamespaceIdent>,
         _: AllowAllAuthState,
@@ -73,7 +72,7 @@ impl AuthZHandler for AllowAllAuthZHandler {
     }
 
     async fn check_create_namespace(
-        _: &HeaderMap,
+        _: &RequestMetadata,
         _: &WarehouseIdent,
         _: Option<&NamespaceIdent>,
         _: AllowAllAuthState,
@@ -82,7 +81,7 @@ impl AuthZHandler for AllowAllAuthZHandler {
     }
 
     async fn check_load_namespace_metadata(
-        _: &HeaderMap,
+        _: &RequestMetadata,
         _: &WarehouseIdent,
         _: &NamespaceIdent,
         _: AllowAllAuthState,
@@ -93,7 +92,7 @@ impl AuthZHandler for AllowAllAuthZHandler {
     // Should check if the user is allowed to check if a namespace exists,
     // not check if the namespace exists.
     async fn check_namespace_exists(
-        _: &HeaderMap,
+        _: &RequestMetadata,
         _: &WarehouseIdent,
         _: &NamespaceIdent,
         _: AllowAllAuthState,
@@ -102,7 +101,7 @@ impl AuthZHandler for AllowAllAuthZHandler {
     }
 
     async fn check_drop_namespace(
-        _: &HeaderMap,
+        _: &RequestMetadata,
         _: &WarehouseIdent,
         _: &NamespaceIdent,
         _: AllowAllAuthState,
@@ -111,7 +110,7 @@ impl AuthZHandler for AllowAllAuthZHandler {
     }
 
     async fn check_update_namespace_properties(
-        _: &HeaderMap,
+        _: &RequestMetadata,
         _: &WarehouseIdent,
         _: &NamespaceIdent,
         _: AllowAllAuthState,
@@ -120,7 +119,7 @@ impl AuthZHandler for AllowAllAuthZHandler {
     }
 
     async fn check_create_table(
-        _: &HeaderMap,
+        _: &RequestMetadata,
         _: &WarehouseIdent,
         _: &NamespaceIdent,
         _: AllowAllAuthState,
@@ -129,7 +128,7 @@ impl AuthZHandler for AllowAllAuthZHandler {
     }
 
     async fn check_list_tables(
-        _: &HeaderMap,
+        _: &RequestMetadata,
         _: &WarehouseIdent,
         _: &NamespaceIdent,
         _: AllowAllAuthState,
@@ -138,7 +137,7 @@ impl AuthZHandler for AllowAllAuthZHandler {
     }
 
     async fn check_rename_table(
-        _: &HeaderMap,
+        _: &RequestMetadata,
         _: &WarehouseIdent,
         _: Option<&TableIdentUuid>,
         _: AllowAllAuthState,
@@ -147,7 +146,7 @@ impl AuthZHandler for AllowAllAuthZHandler {
     }
 
     async fn check_load_table(
-        _: &HeaderMap,
+        _: &RequestMetadata,
         _: &WarehouseIdent,
         _: Option<&NamespaceIdent>,
         _: Option<&TableIdentUuid>,
@@ -157,7 +156,7 @@ impl AuthZHandler for AllowAllAuthZHandler {
     }
 
     async fn check_table_exists(
-        _: &HeaderMap,
+        _: &RequestMetadata,
         _: &WarehouseIdent,
         _: Option<&NamespaceIdent>,
         _: Option<&TableIdentUuid>,
@@ -167,7 +166,7 @@ impl AuthZHandler for AllowAllAuthZHandler {
     }
 
     async fn check_drop_table(
-        _: &HeaderMap,
+        _: &RequestMetadata,
         _: &WarehouseIdent,
         _: Option<&TableIdentUuid>,
         _: AllowAllAuthState,
@@ -176,7 +175,7 @@ impl AuthZHandler for AllowAllAuthZHandler {
     }
 
     async fn check_commit_table(
-        _: &HeaderMap,
+        _: &RequestMetadata,
         _: &WarehouseIdent,
         _: Option<&TableIdentUuid>,
         _: Option<&NamespaceIdent>,

--- a/crates/iceberg-rest-server/src/lib.rs
+++ b/crates/iceberg-rest-server/src/lib.rs
@@ -17,3 +17,4 @@ pub use service::{ProjectIdent, SecretIdent, WarehouseIdent};
 pub use config::CONFIG;
 
 pub mod implementations;
+mod tracing;

--- a/crates/iceberg-rest-server/src/lib.rs
+++ b/crates/iceberg-rest-server/src/lib.rs
@@ -17,4 +17,4 @@ pub use service::{ProjectIdent, SecretIdent, WarehouseIdent};
 pub use config::CONFIG;
 
 pub mod implementations;
-mod tracing;
+pub(crate) mod tracing;

--- a/crates/iceberg-rest-server/src/lib.rs
+++ b/crates/iceberg-rest-server/src/lib.rs
@@ -17,4 +17,5 @@ pub use service::{ProjectIdent, SecretIdent, WarehouseIdent};
 pub use config::CONFIG;
 
 pub mod implementations;
+mod request_metadata;
 pub(crate) mod tracing;

--- a/crates/iceberg-rest-server/src/request_metadata.rs
+++ b/crates/iceberg-rest-server/src/request_metadata.rs
@@ -1,0 +1,28 @@
+use axum::middleware::Next;
+use axum::response::Response;
+use http::HeaderMap;
+use iceberg_rest_service::RequestMetadata;
+use std::str::FromStr;
+use uuid::Uuid;
+
+pub(crate) async fn set_request_metadata(
+    headers: HeaderMap,
+    mut request: axum::extract::Request,
+    next: Next,
+) -> Response {
+    let request_id: Uuid = headers
+        .get("x-request-id")
+        .and_then(|hv| {
+            hv.to_str()
+                .map(Uuid::from_str)
+                .ok()
+                .transpose()
+                .ok()
+                .flatten()
+        })
+        .unwrap_or(Uuid::now_v7());
+    request
+        .extensions_mut()
+        .insert(RequestMetadata { request_id });
+    next.run(request).await
+}

--- a/crates/iceberg-rest-server/src/service/auth.rs
+++ b/crates/iceberg-rest-server/src/service/auth.rs
@@ -1,6 +1,6 @@
 use super::{ProjectIdent, TableIdentUuid, WarehouseIdent};
-use http::HeaderMap;
 use iceberg_rest_service::v1::{NamespaceIdent, Result};
+use iceberg_rest_service::RequestMetadata;
 
 #[derive(Clone, Debug)]
 pub enum UserID {
@@ -54,21 +54,21 @@ where
     type State: Clone + Send + Sync + 'static;
 
     async fn check_list_namespace(
-        headers: &HeaderMap,
+        metadata: &RequestMetadata,
         warehouse_id: &WarehouseIdent,
         parent: Option<&NamespaceIdent>,
         state: Self::State,
     ) -> Result<()>;
 
     async fn check_create_namespace(
-        headers: &HeaderMap,
+        metadata: &RequestMetadata,
         warehouse_id: &WarehouseIdent,
         parent: Option<&NamespaceIdent>,
         state: Self::State,
     ) -> Result<()>;
 
     async fn check_load_namespace_metadata(
-        headers: &HeaderMap,
+        metadata: &RequestMetadata,
         warehouse_id: &WarehouseIdent,
         namespace: &NamespaceIdent,
         state: Self::State,
@@ -77,35 +77,35 @@ where
     /// Check if the user is allowed to check if a namespace exists,
     /// not check if the namespace exists.
     async fn check_namespace_exists(
-        headers: &HeaderMap,
+        metadata: &RequestMetadata,
         warehouse_id: &WarehouseIdent,
         namespace: &NamespaceIdent,
         state: Self::State,
     ) -> Result<()>;
 
     async fn check_drop_namespace(
-        headers: &HeaderMap,
+        metadata: &RequestMetadata,
         warehouse_id: &WarehouseIdent,
         namespace: &NamespaceIdent,
         state: Self::State,
     ) -> Result<()>;
 
     async fn check_update_namespace_properties(
-        headers: &HeaderMap,
+        metadata: &RequestMetadata,
         warehouse_id: &WarehouseIdent,
         namespace: &NamespaceIdent,
         state: Self::State,
     ) -> Result<()>;
 
     async fn check_create_table(
-        headers: &HeaderMap,
+        metadata: &RequestMetadata,
         warehouse_id: &WarehouseIdent,
         namespace: &NamespaceIdent,
         state: Self::State,
     ) -> Result<()>;
 
     async fn check_list_tables(
-        headers: &HeaderMap,
+        metadata: &RequestMetadata,
         warehouse_id: &WarehouseIdent,
         namespace: &NamespaceIdent,
         state: Self::State,
@@ -123,7 +123,7 @@ where
     /// - `namespace`: The namespace the table is in. (Direct parent)
     ///
     async fn check_load_table(
-        headers: &HeaderMap,
+        metadata: &RequestMetadata,
         warehouse_id: &WarehouseIdent,
         namespace: Option<&NamespaceIdent>,
         table: Option<&TableIdentUuid>,
@@ -134,14 +134,14 @@ where
     /// For rename to work, also "check_create_table" must pass
     /// for the destination namespace.
     async fn check_rename_table(
-        headers: &HeaderMap,
+        metadata: &RequestMetadata,
         warehouse_id: &WarehouseIdent,
         source: Option<&TableIdentUuid>,
         state: Self::State,
     ) -> Result<()>;
 
     async fn check_table_exists(
-        headers: &HeaderMap,
+        metadata: &RequestMetadata,
         warehouse_id: &WarehouseIdent,
         namespace: Option<&NamespaceIdent>,
         table: Option<&TableIdentUuid>,
@@ -149,14 +149,14 @@ where
     ) -> Result<()>;
 
     async fn check_drop_table(
-        headers: &HeaderMap,
+        metadata: &RequestMetadata,
         warehouse_id: &WarehouseIdent,
         table: Option<&TableIdentUuid>,
         state: Self::State,
     ) -> Result<()>;
 
     async fn check_commit_table(
-        headers: &HeaderMap,
+        metadata: &RequestMetadata,
         warehouse_id: &WarehouseIdent,
         table: Option<&TableIdentUuid>,
         namespace: Option<&NamespaceIdent>,
@@ -191,7 +191,7 @@ where
     /// `get_config_for_warehouse` permission for a warehouse_id.
     async fn get_and_validate_user_warehouse(
         state: A::State,
-        headers: &HeaderMap,
+        metadata: &RequestMetadata,
     ) -> Result<UserWarehouse>;
 
     /// Enrich / Exchange the token that is used for all further requests
@@ -202,7 +202,7 @@ where
     /// if no change to the original token is required, return Ok(None).
     async fn exchange_token_for_warehouse(
         state: A::State,
-        previous_headers: &HeaderMap,
+        previous_request_metadata: &RequestMetadata,
         project_id: &ProjectIdent,
         warehouse_id: &WarehouseIdent,
     ) -> Result<Option<String>>;

--- a/crates/iceberg-rest-server/src/service/router.rs
+++ b/crates/iceberg-rest-server/src/service/router.rs
@@ -40,7 +40,9 @@ pub fn new_full_router<
     Router::new()
         .nest("/catalog/v1", v1_routes)
         .nest("/management/v1", management_routes)
-        .layer(axum::middleware::from_fn(crate::tracing::set_request_id))
+        .layer(axum::middleware::from_fn(
+            crate::request_metadata::set_request_metadata,
+        ))
         .layer(
             ServiceBuilder::new()
                 .set_x_request_id(MakeRequestUuid)

--- a/crates/iceberg-rest-server/src/service/router.rs
+++ b/crates/iceberg-rest-server/src/service/router.rs
@@ -1,9 +1,14 @@
 use crate::service::event_publisher::EventPublisher;
+use crate::tracing::RestMakeSpan;
+
 use axum::Router;
 use iceberg_rest_service::{new_v1_full_router, shutdown_signal, ApiContext};
+use tower::ServiceBuilder;
+use tower_http::request_id::MakeRequestUuid;
 use tower_http::{
     catch_panic::CatchPanicLayer, compression::CompressionLayer,
     sensitive_headers::SetSensitiveHeadersLayer, timeout::TimeoutLayer, trace, trace::TraceLayer,
+    ServiceBuilderExt,
 };
 
 use super::{
@@ -32,20 +37,26 @@ pub fn new_full_router<
         State<A, C, S, P>,
     >();
     let management_routes = Router::new().merge(crate::api::ApiServer::v1_router());
-
     Router::new()
         .nest("/catalog/v1", v1_routes)
         .nest("/management/v1", management_routes)
-        .layer((
-            SetSensitiveHeadersLayer::new([axum::http::header::AUTHORIZATION]),
-            CompressionLayer::new(),
-            TraceLayer::new_for_http()
-                .on_failure(())
-                .make_span_with(trace::DefaultMakeSpan::new().level(tracing::Level::INFO))
-                .on_response(trace::DefaultOnResponse::new().level(tracing::Level::DEBUG)),
-            TimeoutLayer::new(std::time::Duration::from_secs(30)),
-            CatchPanicLayer::new(),
-        ))
+        .layer(
+            ServiceBuilder::new()
+                .set_x_request_id(MakeRequestUuid)
+                .layer(CatchPanicLayer::new())
+                .layer(SetSensitiveHeadersLayer::new([
+                    axum::http::header::AUTHORIZATION,
+                ]))
+                .layer(
+                    TraceLayer::new_for_http()
+                        .on_failure(())
+                        .make_span_with(RestMakeSpan::new(tracing::Level::INFO))
+                        .on_response(trace::DefaultOnResponse::new().level(tracing::Level::DEBUG)),
+                )
+                .layer(CompressionLayer::new())
+                .layer(TimeoutLayer::new(std::time::Duration::from_secs(30)))
+                .propagate_x_request_id(),
+        )
         .with_state(ApiContext {
             v1_state: State {
                 auth: auth_state,

--- a/crates/iceberg-rest-server/src/service/router.rs
+++ b/crates/iceberg-rest-server/src/service/router.rs
@@ -40,6 +40,7 @@ pub fn new_full_router<
     Router::new()
         .nest("/catalog/v1", v1_routes)
         .nest("/management/v1", management_routes)
+        .layer(axum::middleware::from_fn(crate::tracing::set_request_id))
         .layer(
             ServiceBuilder::new()
                 .set_x_request_id(MakeRequestUuid)

--- a/crates/iceberg-rest-server/src/tracing.rs
+++ b/crates/iceberg-rest-server/src/tracing.rs
@@ -1,0 +1,50 @@
+use http::Request;
+use tower_http::trace::MakeSpan;
+use tracing::{Level, Span};
+
+/// A `MakeSpan` implementation that attaches the request_id to the span.
+#[derive(Debug, Clone)]
+pub(crate) struct RestMakeSpan {
+    level: Level,
+}
+
+impl RestMakeSpan {
+    /// Create a [tracing span] with a certain [`Level`].
+    ///
+    /// [tracing span]: https://docs.rs/tracing/latest/tracing/#spans
+    pub(crate) fn new(level: Level) -> Self {
+        Self { level }
+    }
+}
+
+/// tower-http's `MakeSpan` implementation does not attach a request_id to the span. The impl below
+/// does.
+impl<B> MakeSpan<B> for RestMakeSpan {
+    fn make_span(&mut self, request: &Request<B>) -> Span {
+        // This ugly macro is needed, unfortunately, because `tracing::span!`
+        // required the level argument to be static. Meaning we can't just pass
+        // `self.level`.
+        macro_rules! make_span {
+            ($level:expr) => {
+                    tracing::span!(
+                        $level,
+                        "request",
+                        method = %request.method(),
+                        uri = %request.uri(),
+                        version = ?request.version(),
+                        request_id = %request
+                                    .headers()
+                                    .get("x-request-id")
+                                    .and_then(|v| v.to_str().ok())
+                                    .unwrap_or("MISSING-REQUEST-ID"))
+            }
+        }
+        match self.level {
+            Level::TRACE => make_span!(tracing::Level::TRACE),
+            Level::DEBUG => make_span!(tracing::Level::DEBUG),
+            Level::INFO => make_span!(tracing::Level::INFO),
+            Level::WARN => make_span!(tracing::Level::WARN),
+            Level::ERROR => make_span!(tracing::Level::ERROR),
+        }
+    }
+}

--- a/crates/iceberg-rest-server/src/tracing.rs
+++ b/crates/iceberg-rest-server/src/tracing.rs
@@ -1,6 +1,7 @@
 use axum::middleware::Next;
 use axum::response::Response;
 use http::{HeaderMap, Request, StatusCode};
+use std::str::FromStr;
 use tower_http::trace::MakeSpan;
 use tracing::{Level, Span};
 use uuid::Uuid;
@@ -39,7 +40,9 @@ impl<B> MakeSpan<B> for RestMakeSpan {
                                     .headers()
                                     .get("x-request-id")
                                     .and_then(|v| v.to_str().ok())
-                                    .unwrap_or("MISSING-REQUEST-ID"))
+                                    .unwrap_or("MISSING-REQUEST-ID"),
+                        )
+
             }
         }
         match self.level {
@@ -52,7 +55,7 @@ impl<B> MakeSpan<B> for RestMakeSpan {
     }
 }
 
-async fn set_request_id(
+pub(crate) async fn set_request_id(
     // run the `HeaderMap` extractor
     headers: HeaderMap,
     // you can also add more extractors here but the last
@@ -61,15 +64,22 @@ async fn set_request_id(
     request: axum::extract::Request,
     next: Next,
 ) -> Response {
-    let request_id = headers
+    let request_id: Uuid = headers
         .get("x-request-id")
-        .map(|hv| hv.to_str().ok().map(ToString::to_string))
+        .map(|hv| {
+            hv.to_str()
+                .map(Uuid::from_str)
+                .ok()
+                .transpose()
+                .ok()
+                .flatten()
+        })
         .flatten()
-        .unwrap_or(Uuid::now_v7().to_string());
+        .unwrap_or(Uuid::now_v7());
     let fut = next.run(request);
-    REQUEST_ID.scope(request_id.clone(), fut).await
+    REQUEST_ID.scope(request_id, fut).await
 }
 
 tokio::task_local! {
-    pub(crate) static REQUEST_ID: String;
+    pub(crate) static REQUEST_ID: Uuid;
 }

--- a/crates/iceberg-rest-service/src/service.rs
+++ b/crates/iceberg-rest-service/src/service.rs
@@ -23,6 +23,7 @@ pub struct RequestMetadata {
 
 impl RequestMetadata {
     #[cfg(test)]
+    #[must_use]
     pub fn new_random() -> Self {
         Self {
             request_id: Uuid::new_v4(),

--- a/crates/iceberg-rest-service/src/service.rs
+++ b/crates/iceberg-rest-service/src/service.rs
@@ -21,6 +21,15 @@ pub struct RequestMetadata {
     pub request_id: Uuid,
 }
 
+impl RequestMetadata {
+    #[cfg(test)]
+    pub fn new_random() -> Self {
+        Self {
+            request_id: Uuid::new_v4(),
+        }
+    }
+}
+
 pub type Result<T, E = IcebergErrorResponse> = std::result::Result<T, E>;
 
 pub fn new_v1_full_router<

--- a/crates/iceberg-rest-service/src/service.rs
+++ b/crates/iceberg-rest-service/src/service.rs
@@ -1,5 +1,6 @@
 use axum::Router;
 pub use iceberg_ext::catalog::rest::*;
+use uuid::Uuid;
 
 pub mod v1;
 
@@ -9,6 +10,15 @@ pub trait State: Clone + Send + Sync + 'static {}
 #[derive(Debug, Clone)]
 pub struct ApiContext<S: State> {
     pub v1_state: S,
+}
+
+/// A struct to hold metadata about a request.
+///
+/// Currently, it only holds the `request_id`, later it can be expanded to hold more metadata for
+/// Authz etc.
+#[derive(Debug, Clone)]
+pub struct RequestMetadata {
+    pub request_id: Uuid,
 }
 
 pub type Result<T, E = IcebergErrorResponse> = std::result::Result<T, E>;

--- a/crates/iceberg-rest-service/src/service/v1/config.rs
+++ b/crates/iceberg-rest-service/src/service/v1/config.rs
@@ -1,4 +1,6 @@
-use super::{async_trait, get, ApiContext, CatalogConfig, HeaderMap, Query, Result, Router, State};
+use super::{async_trait, get, ApiContext, CatalogConfig, Query, Result, Router, State};
+use crate::RequestMetadata;
+use axum::Extension;
 
 #[async_trait]
 pub trait Service<S: crate::service::State>
@@ -8,7 +10,7 @@ where
     async fn get_config(
         query: GetConfigQueryParams,
         api_context: ApiContext<S>,
-        headers: HeaderMap,
+        request_metadata: RequestMetadata,
     ) -> Result<CatalogConfig>;
 }
 
@@ -26,7 +28,9 @@ pub fn router<I: Service<S>, S: crate::service::State>() -> Router<ApiContext<S>
         get(
             |Query(query): Query<GetConfigQueryParams>,
              State(api_context): State<ApiContext<S>>,
-             headers: HeaderMap| I::get_config(query, api_context, headers),
+             Extension(metadata): Extension<RequestMetadata>| {
+                I::get_config(query, api_context, metadata)
+            },
         ),
     )
 }

--- a/crates/iceberg-rest-service/src/service/v1/namespace.rs
+++ b/crates/iceberg-rest-service/src/service/v1/namespace.rs
@@ -467,11 +467,11 @@ mod tests {
         let app = router::<TestService, ThisState>();
         let router = axum::Router::new().merge(app).with_state(api_context);
 
-        let req = http::Request::builder()
+        let mut req = http::Request::builder()
             .uri("/test/namespaces?pageToken&pageSize=10")
             .body(axum::body::Body::empty())
             .unwrap();
-
+        req.extensions_mut().insert(RequestMetadata::new_random());
         let r = router.oneshot(req).await.unwrap();
 
         // // parse json body
@@ -568,11 +568,11 @@ mod tests {
         let app = router::<TestService, ThisState>();
         let router = axum::Router::new().merge(app).with_state(api_context);
 
-        let req = http::Request::builder()
+        let mut req = http::Request::builder()
             .uri("/namespaces?pageToken&pageSize=10")
             .body(axum::body::Body::empty())
             .unwrap();
-
+        req.extensions_mut().insert(RequestMetadata::new_random());
         let r = router.oneshot(req).await.unwrap();
         assert_eq!(r.status().as_u16(), 406);
     }
@@ -665,10 +665,11 @@ mod tests {
         let router = axum::Router::new().merge(app).with_state(api_context);
 
         // Test 1: Single identifier
-        let req = http::Request::builder()
+        let mut req = http::Request::builder()
             .uri("/test/namespaces/this-namespace?pageToken&pageSize=10")
             .body(axum::body::Body::empty())
             .unwrap();
+        req.extensions_mut().insert(RequestMetadata::new_random());
 
         let r = router.clone().oneshot(req).await.unwrap();
 
@@ -679,10 +680,11 @@ mod tests {
         assert_eq!(error.error.message, "[\"this-namespace\"]");
 
         // Test 2: Composed identifier
-        let req = http::Request::builder()
+        let mut req = http::Request::builder()
             .uri("/test/namespaces/accounting%1Ftax?pageToken&pageSize=10")
             .body(axum::body::Body::empty())
             .unwrap();
+        req.extensions_mut().insert(RequestMetadata::new_random());
 
         let r = router.oneshot(req).await.unwrap();
         assert_eq!(r.status().as_u16(), 406);

--- a/crates/iceberg-rest-service/src/service/v1/oauth.rs
+++ b/crates/iceberg-rest-service/src/service/v1/oauth.rs
@@ -1,7 +1,9 @@
 use super::{
-    async_trait, post, ApiContext, Form, HeaderMap, OAuthTokenRequest, OAuthTokenResponse, Result,
-    Router, State,
+    async_trait, post, ApiContext, Form, OAuthTokenRequest, OAuthTokenResponse, Result, Router,
+    State,
 };
+use crate::RequestMetadata;
+use axum::Extension;
 
 #[async_trait]
 pub trait Service<S: crate::service::State>
@@ -10,7 +12,7 @@ where
 {
     async fn get_token(
         state: ApiContext<S>,
-        headers: HeaderMap,
+        request_metadata: RequestMetadata,
         // application/x-www-form-urlencoded
         request: OAuthTokenRequest,
     ) -> Result<OAuthTokenResponse>;
@@ -21,10 +23,10 @@ pub fn router<I: Service<S>, S: crate::service::State>() -> Router<ApiContext<S>
         "/oauth/tokens",
         post(
             |State(api_context): State<ApiContext<S>>,
-             headers: HeaderMap,
+             Extension(metadata): Extension<RequestMetadata>,
              // application/x-www-form-urlencoded
              Form(request): Form<OAuthTokenRequest>| {
-                I::get_token(api_context, headers, request)
+                I::get_token(api_context, metadata, request)
             },
         ),
     )

--- a/crates/iceberg-rest-service/src/service/v1/s3_signer.rs
+++ b/crates/iceberg-rest-service/src/service/v1/s3_signer.rs
@@ -1,5 +1,6 @@
-use super::{post, ApiContext, HeaderMap, Json, Prefix, Result, Router, State};
-use axum::{async_trait, extract::Path};
+use super::{post, ApiContext, Json, Prefix, Result, Router, State};
+use crate::RequestMetadata;
+use axum::{async_trait, extract::Path, Extension};
 use iceberg_ext::catalog::rest::{S3SignRequest, S3SignResponse};
 
 #[async_trait]
@@ -21,7 +22,7 @@ where
         table: Option<String>,
         request: S3SignRequest,
         state: ApiContext<S>,
-        headers: HeaderMap,
+        request_metadata: RequestMetadata,
     ) -> Result<S3SignResponse>;
 }
 
@@ -31,10 +32,10 @@ pub fn router<I: Service<S>, S: crate::service::State>() -> Router<ApiContext<S>
             "/aws/s3/sign",
             post(
                 |State(api_context): State<ApiContext<S>>,
-                 headers: HeaderMap,
+                 Extension(metadata): Extension<RequestMetadata>,
                  Json(request): Json<S3SignRequest>| {
                     {
-                        I::sign(None, None, None, request, api_context, headers)
+                        I::sign(None, None, None, request, api_context, metadata)
                     }
                 },
             ),
@@ -44,10 +45,10 @@ pub fn router<I: Service<S>, S: crate::service::State>() -> Router<ApiContext<S>
             post(
                 |Path(prefix): Path<Prefix>,
                  State(api_context): State<ApiContext<S>>,
-                 headers: HeaderMap,
+                 Extension(metadata): Extension<RequestMetadata>,
                  Json(request): Json<S3SignRequest>| {
                     {
-                        I::sign(Some(prefix), None, None, request, api_context, headers)
+                        I::sign(Some(prefix), None, None, request, api_context, metadata)
                     }
                 },
             ),


### PR DESCRIPTION
#59 generates a request_id via tower and makes it available via RequestMetadata in all routes & their handlers
#28 moves to tracing & uses json as logformat